### PR TITLE
fix: Add non-null assertion to weatherDisplay

### DIFF
--- a/script/main.ts
+++ b/script/main.ts
@@ -1,7 +1,7 @@
 let weatherKey: string;
 let locationKey: string;
 
-const weatherDisplay = document.getElementById("weather-display");
+const weatherDisplay = document.getElementById("weather-display")!;
 
 async function loadApiKey(): Promise<void> {
   interface Secrets {


### PR DESCRIPTION
Now it is defined that a weather-display element exists. Otherwise, the program will crash. Until now the compiler complained about what happens if there is no such element but as the program does not work if it doesn't exist, we can tell 'ts' that it always exists.